### PR TITLE
Fix compiler error against Zabbix 3.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ This project is immature and pre-release.
 
 Download [source tarball here](http://s3.cavaliercoder.com/libzbxpython/libzbxpython-1.0.0.tar.gz).
 
+* Build configure scripts
+
+  ```
+  ./autogen.sh
+  ```
 * Configure module sources with the desired Python version, the location of
   Zabbix sources and the install location of the Zabbix configuration directory
 

--- a/src/libzbxpython.c
+++ b/src/libzbxpython.c
@@ -92,7 +92,13 @@ static ZBX_METRIC
 }
 
 // Required Zabbix module functions
+#ifdef ZBX_MODULE_API_VERSION
+// Recommended Zabbix 3.2.x
 int         zbx_module_api_version()                { return ZBX_MODULE_API_VERSION; }
+#else
+// Zabbix 3.0 support
+int         zbx_module_api_version()                { return ZBX_MODULE_API_VERSION_ONE; }
+#endif
 ZBX_METRIC  *zbx_module_item_list()                 { return keys; }
 
 /******************************************************************************


### PR DESCRIPTION
Compiles and works on Centos7 with python 3.4.3 and zabbix 3.0.5. 
Initial tests look like the dummy.py works fine.